### PR TITLE
Add bootstrap target in Makefile to correct timestamps after clone

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -469,6 +469,11 @@ release:
 	make OS=mingw32 clean
 	make OS=mingw32 DEBUG=
 
+# ensure timestamps are correct after fresh git clone, so build can
+# work without already having flexcat installed
+bootstrap:
+	@touch $(CATFILES)
+
 # make the object directories
 $(OBJDIR):
 	@echo "  MK $@"


### PR DESCRIPTION
Might help anyone else getting build errors after a fresh git clone like i did in issue #3, and like me browsing through the Makefile trying to figure out what they are doing wrong.