### PR TITLE
Fixed warnings

### DIFF
--- a/src/createcatsrc.c
+++ b/src/createcatsrc.c
@@ -652,7 +652,7 @@ void CreateSourceFile(char *SourceFile, char *TemplateFile, char *CDFile)
                     char *start;
                     char _StrLen[20 + 1];
 
-                    snprintf(_StrLen, sizeof(_StrLen), "%020" PRIx32, (uint32)cs->ID);
+                    snprintf(_StrLen, sizeof(_StrLen), "%020" PRIx32, (long unsigned int)cs->ID);
                     start = &_StrLen[20 - _len * 2];
                     while(_len > 0)
                     {
@@ -667,7 +667,7 @@ void CreateSourceFile(char *SourceFile, char *TemplateFile, char *CDFile)
                     char *start;
                     char _StrLen[20 + 1];
 
-                    snprintf(_StrLen, sizeof(_StrLen), "%020" PRIx32, (uint32)((CalcRealLength(cs->CD_Str) + 1) & 0xfffffe));
+                    snprintf(_StrLen, sizeof(_StrLen), "%020" PRIx32, (long unsigned int)((CalcRealLength(cs->CD_Str) + 1) & 0xfffffe));
                     start = &_StrLen[20 - _len * 2];
                     while(_len > 0)
                     {


### PR DESCRIPTION
warning: format ‘%020lx’ expects type ‘long unsigned int’, but argument 4 has type ‘unsigned int’