### PR TITLE
Fixed warning.

### DIFF
--- a/src/readprefs.c
+++ b/src/readprefs.c
@@ -107,7 +107,7 @@ char ReadPrefs(void)
 
       if((rda = AllocDosObject(DOS_RDARGS, TAG_DONE)) != NULL)
       {
-        rda->RDA_Source.CS_Buffer = prefs;
+        rda->RDA_Source.CS_Buffer = (UBYTE *)prefs;
         rda->RDA_Source.CS_Length = strlen(prefs);
         rda->RDA_Source.CS_CurChr = 0;
         rda->RDA_Flags |= RDAF_NOPROMPT;

--- a/src/readprefs.c
+++ b/src/readprefs.c
@@ -107,7 +107,7 @@ char ReadPrefs(void)
 
       if((rda = AllocDosObject(DOS_RDARGS, TAG_DONE)) != NULL)
       {
-        rda->RDA_Source.CS_Buffer = (UBYTE *)prefs;
+        rda->RDA_Source.CS_Buffer = (void *)prefs;
         rda->RDA_Source.CS_Length = strlen(prefs);
         rda->RDA_Source.CS_CurChr = 0;
         rda->RDA_Flags |= RDAF_NOPROMPT;


### PR DESCRIPTION
readprefs.c: In function 'ReadPrefs':
readprefs.c:110:35: warning: pointer targets in assignment differ in signedness [-Wpointer-sign]
         rda->RDA_Source.CS_Buffer = prefs;